### PR TITLE
[feat] 수량 조절 #29

### DIFF
--- a/src/components/CartList/CartList.tsx
+++ b/src/components/CartList/CartList.tsx
@@ -45,19 +45,22 @@ export const CartList: React.FC = () => {
       <table className={styles.cartTable}>
         <CartListHeader />
         <tbody>
-          {cart.map(({ id, title, coverImage, price, score, availableCoupon }: IProductType) => (
-            <CartProduct
-              key={id}
-              id={id}
-              title={title}
-              coverImage={coverImage}
-              price={price}
-              score={score}
-              availableCoupon={availableCoupon}
-              onCheck={checkHandler}
-              checked={checkProducts.some((productId) => productId === id)}
-            />
-          ))}
+          {cart.map(
+            ({ id, title, coverImage, price, score, availableCoupon, count }: IProductType) => (
+              <CartProduct
+                key={id}
+                id={id}
+                title={title}
+                coverImage={coverImage}
+                price={price}
+                score={score}
+                availableCoupon={availableCoupon}
+                count={count}
+                onCheck={checkHandler}
+                checked={checkProducts.some((productId) => productId === id)}
+              />
+            )
+          )}
         </tbody>
       </table>
       <CartSelectBtn onCheck={checkAllHandler} onDelete={removeFromCheckHandler} />

--- a/src/components/CartListHeader/styles.module.css
+++ b/src/components/CartListHeader/styles.module.css
@@ -8,3 +8,7 @@
   border: none;
   padding: 1rem;
 }
+
+.price {
+  min-width: 8rem;
+}

--- a/src/components/CartProduct/CartProduct.tsx
+++ b/src/components/CartProduct/CartProduct.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './styles.module.css';
 import { ICartProductType } from '../../interfaces';
-import { AiOutlineMinus, AiOutlinePlus } from 'react-icons/ai';
+import { FiMinus, FiPlus } from 'react-icons/fi';
 import { useStateValue } from '../../context';
 
 export const CartProduct: React.FC<ICartProductType> = ({
@@ -66,17 +66,11 @@ export const CartProduct: React.FC<ICartProductType> = ({
       <td className={`${styles.countBox} ${styles.box}`}>
         <div className={styles.counter}>
           <button className={styles.minus} onClick={countDownHandler}>
-            <AiOutlineMinus />
+            <FiMinus />
           </button>
-          <input
-            className={styles.count}
-            type={'text'}
-            readOnly
-            defaultValue={count}
-            value={count}
-          />
+          <input className={styles.count} type={'text'} readOnly value={count} />
           <button className={styles.plus} onClick={countUpHandler}>
-            <AiOutlinePlus />
+            <FiPlus />
           </button>
         </div>
       </td>

--- a/src/components/CartProduct/CartProduct.tsx
+++ b/src/components/CartProduct/CartProduct.tsx
@@ -11,16 +11,37 @@ export const CartProduct: React.FC<ICartProductType> = ({
   price,
   score,
   availableCoupon,
+  count,
   onCheck,
   checked,
 }) => {
-  const [state, dispatch] = useStateValue();
+  const [{ cart }, dispatch] = useStateValue();
 
   const removeFromCartHandler = () => {
     dispatch({
       type: 'REMOVE_FROM_CART',
       id: id,
     });
+  };
+
+  const countUpHandler = () => {
+    dispatch({
+      type: 'COUNT_UP_FROM_CART',
+      id: id,
+      count: count,
+    });
+  };
+
+  const countDownHandler = () => {
+    if (count > 1) {
+      dispatch({
+        type: 'COUNT_DOWN_FROM_CART',
+        id: id,
+        count: count,
+      });
+    } else {
+      alert('최소 1개의 수량은 포함되어야 합니다.');
+    }
   };
 
   return (
@@ -44,17 +65,23 @@ export const CartProduct: React.FC<ICartProductType> = ({
       </td>
       <td className={`${styles.countBox} ${styles.box}`}>
         <div className={styles.counter}>
-          <button className={styles.minus}>
+          <button className={styles.minus} onClick={countDownHandler}>
             <AiOutlineMinus />
           </button>
-          <input className={styles.count} type={'text'} readOnly defaultValue={1} />
-          <button className={styles.plus}>
+          <input
+            className={styles.count}
+            type={'text'}
+            readOnly
+            defaultValue={count}
+            value={count}
+          />
+          <button className={styles.plus} onClick={countUpHandler}>
             <AiOutlinePlus />
           </button>
         </div>
       </td>
       <td className={`${styles.priceBox} ${styles.box}`}>
-        <div className={styles.price}>{price.toLocaleString()}</div>
+        <div className={styles.price}>{(price * count).toLocaleString()}</div>
       </td>
       <td className={`${styles.deleteBox} ${styles.box}`}>
         <button className={styles.delete} onClick={removeFromCartHandler}>

--- a/src/components/CouponSelect/CouponSelect.tsx
+++ b/src/components/CouponSelect/CouponSelect.tsx
@@ -13,9 +13,7 @@ export const CouponSelect: React.FC<ICouponSelect> = ({ url }) => {
   return (
     <div className={styles.couponSelectBox}>
       <select className={styles.couponSelect}>
-        <option value="" selected disabled hidden>
-          쿠폰을 선택해주세요.
-        </option>
+        <option hidden>쿠폰을 선택해주세요.</option>
         {coupons.map(({ type, title }, idx) => (
           <option key={idx} value={type}>
             {title}

--- a/src/components/Product/Product.tsx
+++ b/src/components/Product/Product.tsx
@@ -11,6 +11,7 @@ export const Product: React.FC<IProductType> = ({
   price,
   score,
   availableCoupon = true,
+  count = 1,
 }) => {
   const [pick, setPick] = useState(false);
   const [{ cart }, dispatch] = useStateValue();
@@ -31,6 +32,7 @@ export const Product: React.FC<IProductType> = ({
           price,
           score,
           availableCoupon,
+          count,
         },
       });
     } else {

--- a/src/components/ProductList/ProductList.tsx
+++ b/src/components/ProductList/ProductList.tsx
@@ -6,7 +6,7 @@ import { IProductListType } from '../../interfaces';
 export const ProductList: React.FC<IProductListType> = ({ products }) => {
   return (
     <div className={styles.productList}>
-      {products.map(({ id, title, coverImage, price, score, availableCoupon }) => (
+      {products.map(({ id, title, coverImage, price, score, availableCoupon, count }) => (
         <Product
           key={id}
           id={id}
@@ -15,6 +15,7 @@ export const ProductList: React.FC<IProductListType> = ({ products }) => {
           price={price}
           score={score}
           availableCoupon={availableCoupon}
+          count={count}
         />
       ))}
     </div>

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -13,18 +13,50 @@ export const reducer = (state: IStateType, action: IActiontype): IStateType => {
       };
     case 'REMOVE_FROM_CART':
       // 제일 처음에 나오는 인덱스 반환
-      const index = state.cart.findIndex((cartItem: IProductType) => cartItem.id === action.id);
-      const newCart = [...state.cart];
-      if (index >= 0) {
-        newCart.splice(index, 1); // 해당 인덱스 빼내기 -> arr에 해당 인덱스에 해당하는 값이 하나 빠진다.
+      const rmIndex = state.cart.findIndex((cartItem: IProductType) => cartItem.id === action.id);
+      const rmNewCart = [...state.cart];
+      if (rmIndex >= 0) {
+        rmNewCart.splice(rmIndex, 1); // 해당 인덱스 빼내기 -> arr에 해당 인덱스에 해당하는 값이 하나 빠진다.
       } else {
         console.warn(`${action.id}가 장바구니에 존재하지 않습니다!`);
       }
       return {
         ...state,
-        cart: newCart,
+        cart: rmNewCart,
       };
-    case 'EMPTY_Cart':
+    case 'COUNT_UP_FROM_CART':
+      // 제일 처음에 나오는 인덱스 반환
+      const upIndex = state.cart.findIndex((cartItem: IProductType) => cartItem.id === action.id);
+      const upNewCart = [...state.cart];
+      if (upIndex >= 0) {
+        const upNewProduct = upNewCart[upIndex];
+        const count = action.count || 0;
+        upNewProduct.count = count + 1;
+        upNewCart.splice(upIndex, 1, upNewProduct);
+      } else {
+        console.warn(`${action.id}가 장바구니에 존재하지 않습니다!`);
+      }
+      return {
+        ...state,
+        cart: upNewCart,
+      };
+    case 'COUNT_DOWN_FROM_CART':
+      // 제일 처음에 나오는 인덱스 반환
+      const downIndex = state.cart.findIndex((cartItem: IProductType) => cartItem.id === action.id);
+      const downNewCart = [...state.cart];
+      if (downIndex >= 0) {
+        const downNewProduct = downNewCart[downIndex];
+        const count = action.count || 0;
+        downNewProduct.count = count - 1;
+        downNewCart.splice(downIndex, 1, downNewProduct);
+      } else {
+        console.warn(`${action.id}가 장바구니에 존재하지 않습니다!`);
+      }
+      return {
+        ...state,
+        cart: downNewCart,
+      };
+    case 'EMPTY_CART':
       return {
         ...state,
         cart: [],

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,6 +5,7 @@ export interface IProductType {
   price: number;
   score: number;
   availableCoupon?: boolean;
+  count: number;
 }
 
 export interface ICartProductType extends IProductType {
@@ -37,6 +38,7 @@ export interface IActiontype {
   type: string;
   id?: string;
   item?: IProductType;
+  count?: number;
 }
 
 export type ContextType = [IStateType, React.Dispatch<IActiontype>];


### PR DESCRIPTION
## PR 요약

> [feat] 수량 조절
> - '-' 버튼 클릭시 숫자 다운 1 미만시 카운터 중지
> - '+'버튼 클릭시 숫자 업
> - IProductType에 count 추가
> - 리듀서에 count up/down 추가

> [fix] select selected 옵션 에러
> - selected 대신 defaultValue와 value 권장
> - hidden처리 옵션이므로 selected와 value 둘다 제거

> [fix] CartProduct 에러
> - defaultValue와 value 충돌로 인해 defaultValue 제거
> - react-icons pId에러로 인해 아이콘 교체

## 체크리스트

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

## 관련 이슈

- resolve #29 

## 기타(스크린샷 등)

> <img src="https://user-images.githubusercontent.com/46251629/99364909-ea6e5880-28f9-11eb-8c5e-eea8c8481618.png" width="600px"/>
